### PR TITLE
fixed bug where user can follow user with id -1

### DIFF
--- a/api.go
+++ b/api.go
@@ -132,10 +132,15 @@ func APIPostFollows(w http.ResponseWriter, r *http.Request) {
 	// Insert or delete from database depending on follow or unfollow.
 	if action.Follow != "" {
 		followId := get_user_id(action.Follow)
-		database.Create(&Follower{
-			Who_id:  userId,
-			Whom_id: followId,
-		})
+		if followId != -1 {
+			database.Create(&Follower{
+				Who_id:  userId,
+				Whom_id: followId,
+			})
+		} else {
+			writeJSON(w, http.StatusNotFound, "User to follow not found (no response body)")
+			return
+		}
 	} else if action.Unfollow != "" {
 		unfollowId := get_user_id(action.Unfollow)
 		database.Where("who_id = ? AND whom_id = ?", userId, unfollowId).Delete(&Follower{})


### PR DESCRIPTION
Tested by emptying the DB, then registering user "a", then trying to follow "b" (who isn't yet registered):

curl -i -X POST "http://localhost:5001/api/register" -H "Content-Type: application/json" -d '{"username":"a","pwd":"pw","email":"a@a.d"}'

 curl -i -X POST "http://localhost:5001/api/fllws/a" -H "Authorization: Basic ${TOKEN}" -H "Content-Type: application/json" -d '{"follow":"b"}'
 
 Response:
 "User to follow not found (no response body)"
 
 All API tests still pass