### PR TITLE
Snyk add

### DIFF
--- a/.github/workflows/develop-pr.yml
+++ b/.github/workflows/develop-pr.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v4
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -30,3 +30,31 @@ jobs:
     needs: quality-gate
     uses: ./.github/workflows/merged-tests.yml
     secrets: inherit 
+
+  snyk-container-scan:
+    name: Snyk Container Scan
+    runs-on: ubuntu-latest
+    needs: quality-gate
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+
+      - name: Set up Snyk
+        uses: snyk/actions/setup@master
+
+      - name: Build API image for scan
+        run: docker build -f Dockerfile.api -t minitwit-api:snyk-scan .
+
+      - name: Scan API Docker image
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        run: snyk container test minitwit-api:snyk-scan --severity-threshold=high || true
+
+      - name: Build Web image for scan
+        run: docker build -f Dockerfile.web -t minitwit-web:snyk-scan .
+
+      - name: Scan Web Docker image
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        run: snyk container test minitwit-web:snyk-scan --severity-threshold=high || true

--- a/.github/workflows/develop-pr.yml
+++ b/.github/workflows/develop-pr.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -35,7 +35,6 @@ jobs:
     name: Snyk Container Scan
     runs-on: ubuntu-latest
     needs: quality-gate
-
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2

--- a/.github/workflows/develop-pr.yml
+++ b/.github/workflows/develop-pr.yml
@@ -42,11 +42,6 @@ jobs:
       - name: Set up Snyk
         uses: snyk/actions/setup@master
 
-      - name: Authenticate Snyk
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        run: snyk auth $SNYK_TOKEN
-
       - name: Build API image for scan
         run: docker build -f Dockerfile.api -t minitwit-api:snyk-scan .
 

--- a/.github/workflows/develop-pr.yml
+++ b/.github/workflows/develop-pr.yml
@@ -42,6 +42,17 @@ jobs:
       - name: Set up Snyk
         uses: snyk/actions/setup@master
 
+      - name: Check Snyk token exists
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        run: |
+          if [ -z "$SNYK_TOKEN" ]; then
+            echo "SNYK_TOKEN is missing"
+            exit 1
+          else
+            echo "SNYK_TOKEN is set"
+          fi
+
       - name: Build API image for scan
         run: docker build -f Dockerfile.api -t minitwit-api:snyk-scan .
 

--- a/.github/workflows/develop-pr.yml
+++ b/.github/workflows/develop-pr.yml
@@ -42,6 +42,11 @@ jobs:
       - name: Set up Snyk
         uses: snyk/actions/setup@master
 
+      - name: Authenticate Snyk
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        run: snyk auth $SNYK_TOKEN
+
       - name: Build API image for scan
         run: docker build -f Dockerfile.api -t minitwit-api:snyk-scan .
 


### PR DESCRIPTION
This PR adds Snyk security scanning to our pull requests.

What it does:
- Builds the API Docker image
- Scans the API image for known security issues
- Builds the Web Docker image
- Scans the Web image for known security issues

Why this is useful:
It helps us find vulnerable packages or dependencies before code is merged.

About `|| true`:
Right now the scan will report problems, but it will not fail the workflow. This is added so we can test Snyk first without blocking everyone's PRs.

Later we can remove `|| true` to make the scan strict and fail PRs when serious vulnerabilities are found.