### PR TITLE
Monitoring fix

### DIFF
--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -5,9 +5,7 @@ services:
       - ./monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
       - prometheus-storage:/prometheus
       - /var/run/docker.sock:/var/run/docker.sock
-    #  ports:
-    #    - "9090:9090"
-    # user: "0:0" Used for local testing
+    user: "0:0" # Run Prometheus as root to access docker socket and host metrics from cadvisor and node_exporter
     networks:
       - minitwit-network
     deploy:


### PR DESCRIPTION
Run Prometheus as root in docker-compose.monitoring.yml as it is (seemingly) the only way to access docker socket and host metrics from cadvisor and node_exporter